### PR TITLE
Add webhook support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -349,9 +349,13 @@ async function removeWebhook(webhookEvents: WebhookEvent[]) {
   }
 }
 
-export async function endpoint({ method, body, path }) {
+export const endpoint: resolvers.Root["endpoint"] = async ({
+  method,
+  body,
+  path,
+}) => {
   if (method === "POST" && path === "/webhook") {
-    const webhook: WebhookPayload = JSON.parse(body);
+    const webhook: WebhookPayload = JSON.parse(body ?? "");
     switch (webhook.type) {
       case "task.created":
         const issue = root.tasks.one({ id: webhook.data.model.id });
@@ -376,7 +380,7 @@ export async function endpoint({ method, body, path }) {
           .$emit();
     }
   }
-}
+};
 
 /**
  * Returns `true` if the given string is a series of numbers

--- a/index.ts
+++ b/index.ts
@@ -3,11 +3,32 @@
  *
  * See the [Height API docs](https://height.notion.site/API-documentation-643aea5bf01742de9232e5971cb4afda) for more information.
  */
-import { root, state, values, handles, resolvers } from "membrane";
+import { root, state, values, handles, resolvers, nodes } from "membrane";
+
+/**
+ * Task events will contain a data attribute with a [task object](https://height.notion.site/The-task-object-d8dff420ddbe4afc8837f493e922be7b) as model.
+ * Activity events will contain a data attribute with a activity object as model.
+ * @see https://height.notion.site/Webhook-event-types-f35f375f41854241820522da30ad81b7
+ */
+const WebhookEvents = [
+  "task.created",
+  "task.updated",
+  "task.deleted",
+  "activity.created",
+  "activity.updated",
+  "activity.deleted",
+] as const;
+
+/**
+ * @see https://height.notion.site/Webhook-event-types-f35f375f41854241820522da30ad81b7
+ */
+type WebhookEvent = (typeof WebhookEvents)[number];
 
 export type State = {
   token?: string;
+  webhooks: Record<WebhookEvent, { id: string; refs: number }>;
 };
+state.webhooks ??= {} as State["webhooks"];
 
 type Options = Omit<RequestInit, "body"> & { body?: object };
 type ExtraOptions = Omit<Options, "method" | "body">;
@@ -27,6 +48,8 @@ api.post = <T>(route: string, body?: object, options?: ExtraOptions) =>
   api<T>(route, { method: "POST", body, ...options });
 api.patch = <T>(route: string, body?: object, options?: ExtraOptions) =>
   api<T>(route, { method: "PATCH", body, ...options });
+api.delete = <T>(route: string, body?: object, options?: ExtraOptions) =>
+  api<T>(route, { method: "DELETE", body, ...options });
 
 const pageParams = (args: { page?: number; pageSize?: number }) => {
   return {
@@ -62,11 +85,38 @@ export const lists = () => ({});
 export const users = () => ({});
 export const tasks = () => ({});
 
+export const taskCreated: resolvers.Root["taskCreated"] = {
+  subscribe() {
+    return ensureWebhook(["task.created"]);
+  },
+  unsubscribe() {
+    return removeWebhook(["task.created"]);
+  },
+};
+
+export const taskUpdated: resolvers.Root["taskUpdated"] = {
+  subscribe() {
+    return ensureWebhook(["task.updated"]);
+  },
+  unsubscribe() {
+    return removeWebhook(["task.updated"]);
+  },
+};
+
+export const taskDeleted: resolvers.Root["taskDeleted"] = {
+  subscribe() {
+    return ensureWebhook(["task.deleted"]);
+  },
+  unsubscribe() {
+    return removeWebhook(["task.deleted"]);
+  },
+};
+
 export const TaskList: resolvers.TaskList = {
   gref(_, { obj }) {
     return root.lists.one({ id: obj.id });
   },
-  async patch(args, { self }) {
+  async update(args, { self }) {
     const id = await self.id.$get();
     const { icon, iconHue, ...otherArgs } = args;
     const list = await api.patch(`lists/${id}`, {
@@ -101,14 +151,52 @@ export const Task: resolvers.Task = {
   parentTask(_, { obj }) {
     return TaskCollection.one!({ id: obj.parentTaskId }, {} as any);
   },
-  async comment({ message }, { self }) {
-    const { id: taskId } = self.$argsAt(root.tasks.one)!;
+  async postComment({ message }, { self }) {
+    let { id: taskId } = self.$argsAt(root.tasks.one)!;
+
+    // The API only accepts UUIDs for task IDs, so we need to resolve the task ID if it's an index
+    if (isTaskIndex(taskId)) {
+      taskId = await self.id.$get();
+    }
+
     const { id } = await api.post<{ id: string }>(`activities`, {
       type: "comment",
       message,
       taskId,
     });
     return root.activities.one({ id });
+  },
+  onActivity: {
+    subscribe() {
+      return ensureWebhook([
+        "activity.created",
+        "activity.updated",
+        "activity.deleted",
+      ]);
+    },
+    unsubscribe() {
+      return removeWebhook([
+        "activity.created",
+        "activity.updated",
+        "activity.deleted",
+      ]);
+    },
+  },
+  onUpdated: {
+    subscribe() {
+      return ensureWebhook(["task.updated"]);
+    },
+    unsubscribe() {
+      return removeWebhook(["task.updated"]);
+    },
+  },
+  onDeleted: {
+    subscribe() {
+      return ensureWebhook(["task.deleted"]);
+    },
+    unsubscribe() {
+      return removeWebhook(["task.deleted"]);
+    },
   },
 };
 
@@ -165,3 +253,135 @@ export const ActivityCollection: resolvers.ActivityCollection = {
     return paginate(self, list, page, pageSize);
   },
 };
+
+/**
+ * @see https://height.notion.site/The-webhook-object-a65788ae2c404d21a4e999f83f1a7fb9
+ */
+interface Webhook extends values.Webhook {
+  /** The unique id of the webhook event */
+  id: string;
+  model: "webhookEvent";
+  /**
+   * The webhook event type. See all event types here:
+   * https://height.notion.site/Webhook-event-types-f35f375f41854241820522da30ad81b7
+   */
+  events: WebhookEvent[];
+}
+
+/**
+ * @see https://height.notion.site/The-webhook-event-object-c7c1d75c072e41d5bf5ca072c6e35a57
+ */
+interface WebhookPayload {
+  id: string;
+  model: "webhookEvent";
+  webhookId: string;
+  type: WebhookEvent;
+  data: {
+    model: Record<string, any>;
+    previousModule?: Record<string, any>;
+  };
+}
+
+export const Webhook: resolvers.Webhook = {
+  gref(_, { obj }) {
+    return root.webhooks.one({ id: obj.id });
+  },
+};
+
+export const WebhookCollection: resolvers.WebhookCollection = {
+  async one({ id }) {
+    const { list: webhooks } = await api<{ list: Webhook[] }>(`webhooks`);
+    return webhooks.find((webhook: Webhook) => webhook.id === id);
+  },
+  async page(args, { self }) {
+    const { page, pageSize } = pageParams(args);
+    const { list } = await api<{ list: Webhook[] }>("webhooks");
+    return paginate(self, list, page, pageSize);
+  },
+};
+
+async function ensureWebhook(webhookEvents: WebhookEvent[]) {
+  const events = new Set(webhookEvents);
+  const { list: webhookList } = await api<{ list: Webhook[] }>("webhooks");
+
+  for (const event of events) {
+    if (state.webhooks[event]) {
+      const webhook = webhookList.find(
+        (webhook) => webhook.id === state.webhooks[event].id
+      );
+
+      if (webhook) {
+        state.webhooks[event].refs++;
+        continue;
+      }
+      delete state.webhooks[event];
+    }
+
+    const webhook = await api.post<Webhook>("webhooks", {
+      url: (await nodes.process.endpointUrl) + "/webhook",
+      events: [event],
+    });
+    state.webhooks[event] = { id: webhook.id, refs: 1 };
+  }
+}
+
+async function removeWebhook(webhookEvents: WebhookEvent[]) {
+  const events = new Set(webhookEvents);
+  const { list: webhookList } = await api<{ list: Webhook[] }>("webhooks");
+
+  for (const event of events) {
+    const webhookRef = state.webhooks[event];
+    if (webhookRef) {
+      if (webhookRef.refs > 1) {
+        webhookRef.refs--;
+        continue;
+      }
+      if (webhookRef.refs === 1) {
+        const webhook = webhookList.find(
+          (webhook) => webhook.id === webhookRef.id
+        );
+        if (webhook) {
+          await api.delete(`webhooks/${webhook.id}`);
+        }
+        delete state.webhooks[event];
+      }
+    }
+  }
+}
+
+export async function endpoint({ method, body, path }) {
+  if (method === "POST" && path === "/webhook") {
+    const webhook: WebhookPayload = JSON.parse(body);
+    switch (webhook.type) {
+      case "task.created":
+        const issue = root.tasks.one({ id: webhook.data.model.id });
+        return root.taskCreated().$emit(issue);
+      case "task.updated":
+        return Promise.all([
+          root.taskUpdated().$emit(webhook.data.model.id),
+          root.tasks.one({ id: webhook.data.model.id }).onUpdated().$emit(),
+        ]);
+      case "task.deleted":
+        return Promise.all([
+          root.taskDeleted().$emit(webhook.data.model.id),
+          root.tasks.one({ id: webhook.data.model.id }).onDeleted().$emit(),
+        ]);
+      case "activity.created":
+      case "activity.updated":
+      case "activity.deleted":
+        console.log("activity event", webhook.type);
+        return root.tasks
+          .one({ id: webhook.data.model.taskId })
+          .onActivity()
+          .$emit();
+    }
+  }
+}
+
+/**
+ * Returns `true` if the given string is a series of numbers
+ * Height tasks are either index numbers or UUIDs, this is a simple way to differentiate between the two.
+ **/
+function isTaskIndex(id: string): boolean {
+  return /^\d+$/.test(id);
+}

--- a/memconfig.json
+++ b/memconfig.json
@@ -129,6 +129,7 @@
           {
             "name": "key",
             "type": "String",
+            "hints": { "primary": true },
             "description": "The unique key of your list is used as their url"
           },
           {

--- a/memconfig.json
+++ b/memconfig.json
@@ -54,6 +54,26 @@
             "name": "activities",
             "type": "ActivityCollection",
             "description": "Collection of activities"
+          },
+          {
+            "name": "webhooks",
+            "type": "WebhookCollection"
+          }
+        ],
+        "events": [
+          {
+            "name": "taskCreated",
+            "type": "Ref",
+            "ofType": "Task"
+          },
+          {
+            "name": "taskUpdated",
+            "type": "Ref",
+            "ofType": "Task"
+          },
+          {
+            "name": "taskDeleted",
+            "type": "String"
           }
         ]
       },
@@ -136,7 +156,7 @@
         ],
         "actions": [
           {
-            "name": "patch",
+            "name": "update",
             "description": "Update a task list. Any parameters not provided will be left unchanged.",
             "type": "Void",
             "params": [
@@ -190,6 +210,20 @@
                 "optional": true
               }
             ]
+          }
+        ],
+        "events": [
+          {
+            "name": "taskCreated",
+            "type": "Void"
+          },
+          {
+            "name": "taskUpdated",
+            "type": "Void"
+          },
+          {
+            "name": "taskDeleted",
+            "type": "Void"
           }
         ]
       },
@@ -338,10 +372,23 @@
             "description": "The date at which the task was deleted"
           }
         ],
-        "events": [],
+        "events": [
+          {
+            "name": "onActivity",
+            "type": "Void"
+          },
+          {
+            "name": "onUpdated",
+            "type": "Void"
+          },
+          {
+            "name": "onDeleted",
+            "type": "Void"
+          }
+        ],
         "actions": [
           {
-            "name": "comment",
+            "name": "postComment",
             "description": "Post a message related to the task",
             "type": "Ref",
             "params": [
@@ -700,6 +747,74 @@
               }
             ],
             "description": "Retrieves a page of activities"
+          }
+        ]
+      },
+      {
+        "name": "Webhook",
+        "fields": [
+          {
+            "name": "id",
+            "type": "String"
+          },
+          {
+            "name": "model",
+            "type": "String"
+          },
+          {
+            "name": "url",
+            "type": "String"
+          },
+          {
+            "name": "events",
+            "type": "List",
+            "ofType": "String"
+          }
+        ]
+      },
+      {
+        "name": "WebhookPage",
+        "fields": [
+          {
+            "name": "items",
+            "type": "List",
+            "ofType": "Webhook"
+          },
+          {
+            "name": "next",
+            "type": "Ref",
+            "ofType": "WebhookPage"
+          }
+        ]
+      },
+      {
+        "name": "WebhookCollection",
+        "fields": [
+          {
+            "name": "one",
+            "type": "Webhook",
+            "params": [
+              {
+                "name": "id",
+                "type": "String"
+              }
+            ]
+          },
+          {
+            "name": "page",
+            "type": "WebhookPage",
+            "params": [
+              {
+                "name": "page",
+                "type": "Int",
+                "optional": true
+              },
+              {
+                "name": "pageSize",
+                "type": "Int",
+                "optional": true
+              }
+            ]
           }
         ]
       }

--- a/memconfig.lock
+++ b/memconfig.lock
@@ -278,6 +278,20 @@
                 "hints": {}
               },
               {
+                "name": "scoped",
+                "description": "",
+                "type": "Root",
+                "params": [
+                  {
+                    "name": "url",
+                    "description": "",
+                    "type": "String",
+                    "optional": false
+                  }
+                ],
+                "hints": {}
+              },
+              {
                 "name": "gref",
                 "description": "A reference to this node",
                 "type": "Ref",


### PR DESCRIPTION
Closes T-460

Adds webhook support to the height driver. This includes events for listening when tasks or activities are changed. There's still a bit of work to be done:


- [ ] Add descriptions to the events
- [ ] Add dedicated event types and emit those from the events
- [ ] Figure out if any new events should be created / if activity events should be broken down