### PR TITLE
T-707: Add `listId` filter to tasks.page

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -115,10 +115,14 @@ export const Task: resolvers.Task = {
 export const TaskCollection: resolvers.TaskCollection = {
   one: ({ id }) => api(`tasks/${id}`),
   async page(args, { self }) {
+    const filters = {
+      deleted: { values: [false] },
+      ...(args.listId && { listIds: { values: [args.listId] } }),
+    };
+
+    const params = new URLSearchParams({ filters: JSON.stringify(filters) });
     const { page, pageSize } = pageParams(args);
-    const { list } = await api<{ list: object[] }>(
-      `tasks?filters={"deleted":{"values":[false]}}`
-    );
+    const { list } = await api<{ list: object[] }>(`tasks?${params}`);
     return paginate(self, list, page, pageSize);
   },
 };

--- a/memconfig.json
+++ b/memconfig.json
@@ -74,7 +74,9 @@
           {
             "name": "name",
             "type": "String",
-            "hints": { "primary": true },
+            "hints": {
+              "primary": true
+            },
             "description": "Name of the workspace"
           },
           {
@@ -287,7 +289,9 @@
           {
             "name": "index",
             "type": "Int",
-            "hints": { "primary": true },
+            "hints": {
+              "primary": true
+            },
             "description": "Index of the task"
           },
           {
@@ -299,7 +303,9 @@
           {
             "name": "name",
             "type": "String",
-            "hints": { "primary": true },
+            "hints": {
+              "primary": true
+            },
             "description": "Name of the task"
           },
           {
@@ -450,7 +456,9 @@
           {
             "name": "username",
             "type": "String",
-            "hints": { "primary": true },
+            "hints": {
+              "primary": true
+            },
             "description": "Username of the user"
           },
           {
@@ -584,6 +592,11 @@
                 "type": "Int",
                 "optional": true,
                 "description": "Size of the page"
+              },
+              {
+                "name": "listId",
+                "type": "String",
+                "optional": true
               }
             ],
             "description": "Retrieves a page of tasks"


### PR DESCRIPTION
This allows fetching tasks by list, e.g. to pull our `public-roadmap` from [docs.membrane.io](https://docs.membrane.io).

The Height API actually allows passing multiple list ids (among many other fields), but I am starting small with what we will use now.

_Close T-707_